### PR TITLE
Add pcap ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /*.xlsx
 /*.csv
 /*.png
+/*.pcap

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /*.xlsx
 /*.csv
 /*.png
-/*.pcap
+
+*.pcap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "color-print"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4"
+dependencies = [
+ "color-print-proc-macro",
+]
+
+[[package]]
+name = "color-print-proc-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22"
+dependencies = [
+ "nom",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,12 +612,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -974,6 +1011,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "color-print",
  "csv",
  "indicatif",
  "pcap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
@@ -359,12 +365,33 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -536,6 +563,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libloading"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +647,20 @@ dependencies = [
  "hmac",
  "password-hash",
  "sha2",
+]
+
+[[package]]
+name = "pcap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da544c8115cc65b474554569c7654fc94a4f6a167f79192536e148fd654e17a"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno 0.2.8",
+ "libc",
+ "libloading",
+ "regex",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -709,8 +760,8 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags",
- "errno",
+ "bitflags 2.9.1",
+ "errno 0.3.13",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.60.2",
@@ -925,6 +976,7 @@ dependencies = [
  "clap",
  "csv",
  "indicatif",
+ "pcap",
  "rust_xlsxwriter",
  "serde",
  "toml",
@@ -1008,6 +1060,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,6 +1138,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
 
 [[package]]
@@ -1131,6 +1218,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1140,6 +1233,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1167,6 +1266,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1176,6 +1281,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1200,6 +1311,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1228,7 +1345,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-# calamine = "0.18"
-# lettre = "0.10"
+pcap = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
 csv = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ clap = { version = "4.4", features = ["derive"] }
 rust_xlsxwriter = "0.6"
 indicatif = "0.18.0"
 chrono = "0.4.41"
+color-print = "0.3"
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 ## VALIDATION REPORT GENERATION
 
 ### Features
-- Parse test definitions from a TOML file
-- Filter tests by ID or priority (LOW, MEDIUM, HIGH)
-- Generate a technician-friendly CSV report
-- Includes metadata rows for technician and firmware details
+- Generate grouped sets of tests in TOML format, filter tests by ID or priority (LOW, MEDIUM, HIGH)
+- Protection against script files tampering
+- protection against grouped test toml tampering
+- Generate a technician-friendly Excel report, Includes metadata rows for technician and firmware details
+- Validation test runner
+- Validation email template generator
+- Capture pcap files from test runs
+- Automated sensor system configuration dump
 
 ### Using the tool
 You can run the tool directly using .\vtg.exe.
@@ -143,6 +147,15 @@ Run all in instruction file
 Specify an instruction toml file
 - .\vtg.exe --test -i Path/To/Instruction.toml
 
+### Pcap capturing
+
+This tool can automatically capture pcap files during the test run.
+
+The pcap files are generated into the directory /pcaps.
+
+Rerunning same tests will remove the last pcap file for that test and start a new one.
+
+
 ### Generating the email template
 
 To generate the email template, ensure that a report named `validation_test_report.xlsx` already exists in the source directory. This file is used as input to create a technician-ready HTML email preview.
@@ -156,3 +169,13 @@ The email includes:
 Once ready, run:
 
 - .\vtg.exe --email-gen example.sender@example.com example.recipient@example.com
+
+
+### Automated sensor system configuration dump
+
+This tool can automatically do configuration dump from a powered sensor.
+
+To bypass this functionality in the event of sensor not working, you can run the email
+generator command with the bypass flag.
+
+The sensor configuration dump with output to an email attachment directory.

--- a/README_validator.md
+++ b/README_validator.md
@@ -1,8 +1,13 @@
 ## VALIDATION REPORT GENERATION - validator
 
 ### Features
+- Protection against script files tampering
+- protection against grouped test toml tampering
+- Generate a technician-friendly Excel report, Includes metadata rows for technician and firmware details
 - Validation test runner
 - Validation email template generator
+- Capture pcap files from test runs
+- Automated sensor system configuration dump
 
 ### Using the tool
 You can run the tool directly using .\vtg.exe.
@@ -68,6 +73,14 @@ Run all in instruction file
 Specify an instruction toml file
 - .\vtg.exe --test -i Path/To/Instruction.toml
 
+### Pcap capturing
+
+This tool can automatically capture pcap files during the test run.
+
+The pcap files are generated into the directory /pcaps.
+
+Rerunning same tests will remove the last pcap file for that test and start a new one.
+
 
 ### Generating the email template
 
@@ -82,3 +95,13 @@ The email includes:
 Once ready, run:
 
 - .\vtg.exe --email-gen example.sender@example.com example.recipient@example.com
+
+
+### Automated sensor system configuration dump
+
+This tool can automatically do configuration dump from a powered sensor.
+
+To bypass this functionality in the event of sensor not working, you can run the email
+generator command with the bypass flag.
+
+The sensor configuration dump with output to an email attachment directory.

--- a/src/ar_process_vti.rs
+++ b/src/ar_process_vti.rs
@@ -3,6 +3,7 @@ use std::fs;
 use toml::Value;
 
 use crate::ar_auto_commands::{auto_command_selector, check_for_auto_commands};
+use crate::pcap_ops::PcapInstance;
 
 pub fn process_fetched_instructions(instructions: &Vec<Value>) -> Result<(), Box<dyn Error>> {
     let mut auto_command: Option<&'static str> = None;
@@ -38,6 +39,8 @@ pub fn ar_process_test_item(file: &str, user_input_test_id: &str) -> Result<(), 
             for test in tests {
                 let test_id = test.get("test_id").and_then(|v| v.as_str()).unwrap_or("");
                 if test_id == user_input_test_id {
+                    let mut pcap_instance = PcapInstance::new(test_id);
+                    pcap_instance.start();
                     println!("Test Group: {}", group_name);
                     println!("Test ID: {}", test_id);
                     let pass_condition = test
@@ -50,6 +53,7 @@ pub fn ar_process_test_item(file: &str, user_input_test_id: &str) -> Result<(), 
                     {
                         process_fetched_instructions(instructions)?;
                     }
+                    pcap_instance.stop();
                     return Ok(());
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,9 @@
 use clap::{CommandFactory, Parser};
 
+// macro_use modules must be declared before modules that use it.
+#[macro_use]
+mod misc;
+
 mod ar_auto_commands;
 mod ar_ccc_commands;
 mod ar_generic_commands;
@@ -8,7 +12,6 @@ mod ar_process_vti;
 mod email_ops;
 mod excel_ops;
 mod interface;
-mod misc;
 mod op_selector;
 mod pcap_ops;
 mod python_env;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod excel_ops;
 mod interface;
 mod misc;
 mod op_selector;
+mod pcap_ops;
 mod python_env;
 mod sanity;
 mod scripts_find;

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -60,3 +60,17 @@ pub fn print_thick_separator() {
 pub fn print_thin_separator() {
     println!("-------------------------------------------------------------------------");
 }
+
+#[macro_export]
+macro_rules! print_warn_ln {
+    ($($arg:tt)*) => {
+        color_print::cprintln!("<yellow>[WARN]</> {}", format!($($arg)*));
+    };
+}
+
+#[macro_export]
+macro_rules! print_help_ln {
+    ($($arg:tt)*) => {
+        color_print::cprintln!("<blue>[HELPER]</> {}", format!($($arg)*));
+    };
+}

--- a/src/pcap_ops.rs
+++ b/src/pcap_ops.rs
@@ -1,0 +1,127 @@
+use std::fs;
+use std::path::PathBuf;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use pcap::{ConnectionStatus, Device};
+use std::net::IpAddr;
+
+const HOST_IP: IpAddr = IpAddr::V4(std::net::Ipv4Addr::new(192, 168, 32, 100));
+
+fn connected_ethernet_device() -> Option<Device> {
+    let all_devices = match Device::list() {
+        Ok(devices) => devices,
+        Err(e) => {
+            eprintln!("[WARN] Failed to list devices: {}", e);
+            return None;
+        }
+    };
+
+    let device = match all_devices
+        .into_iter()
+        .find(|device| device.addresses.iter().any(|addr| addr.addr == HOST_IP))
+    {
+        Some(d) => d,
+        None => {
+            println!("[WARN] No device found with IP {}.", HOST_IP);
+            println!(
+                "[HELPER] Check your system [Network Connections / Adapters] configuration for IP: {}.",
+                HOST_IP
+            );
+            return None;
+        }
+    };
+
+    if device.flags.connection_status != ConnectionStatus::Connected {
+        println!("[WARN] Device with IP {} is not connected.", HOST_IP);
+        println!("[HELPER] Check the ethernet hardware connection.");
+        return None;
+    }
+
+    let desc = device.desc.as_deref().unwrap_or("No description available");
+    println!(
+        "[PCAP] Connected device with IP {}: {} — {}",
+        HOST_IP, device.name, desc
+    );
+
+    Some(device)
+}
+
+pub struct PcapInstance {
+    test_name: String,
+    stop_flag: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+    skip: bool,
+}
+
+impl PcapInstance {
+    pub fn new(test_name: &str) -> Self {
+        let dir = PathBuf::from("pcaps");
+        let mut skip = false;
+
+        if let Err(e) = fs::create_dir_all(&dir) {
+            eprintln!("[WARN] Failed to create pcaps directory: {}", e);
+            skip = true;
+        }
+
+        let pcap_path = dir.join(format!("{}.pcap", test_name));
+        if pcap_path.exists() {
+            if let Err(e) = fs::remove_file(&pcap_path) {
+                eprintln!("[WARN] Failed to remove existing pcap file. {}", e);
+                skip = true;
+            }
+        }
+
+        PcapInstance {
+            test_name: test_name.to_string(),
+            stop_flag: Arc::new(AtomicBool::new(false)),
+            handle: None,
+            skip,
+        }
+    }
+
+    pub fn start(&mut self) {
+        if self.skip {
+            println!("[WARN] Skipping pcap...");
+            return;
+        }
+        if connected_ethernet_device().is_none() {
+            self.skip = true;
+            println!("[WARN] Skipping pcap...");
+            return;
+        }
+
+        println!("[PCAP] started for: {}", self.test_name);
+
+        let flag = Arc::clone(&self.stop_flag);
+        let name = self.test_name.clone();
+        let handle = thread::spawn(move || {
+            while !flag.load(Ordering::Relaxed) {
+                println!("[Thread {}] heartbeat", &name);
+                thread::sleep(Duration::from_secs(5));
+            }
+            println!("[PCAP] received stop signal for: {}", &name);
+        });
+
+        self.handle = Some(handle);
+    }
+
+    pub fn stop(mut self) {
+        if self.skip {
+            println!(
+                "[WARN] Pcap capture was skipped due to some errors in the capture process. This does not affect the testing process or test results."
+            );
+            return;
+        }
+
+        self.stop_flag.store(true, Ordering::Relaxed);
+
+        if let Some(handle) = self.handle.take() {
+            handle.join().expect("[WARN] Failed to join capture thread");
+        }
+    }
+}


### PR DESCRIPTION
This pr adds the functionality to automatically capture pcaps when running validation tests.

It will provide warnings and help messages for any pcap related issues and it will not halt the test process. Tests can continue with the pcap warnings as usual.

No bypass flag is necessary yet since all the pcap errors are handled as warnings and will simply skip the capture pcap process of the validation test runner.